### PR TITLE
Fixes typos in Using-the-Compiler-API.md

### DIFF
--- a/Using-the-Compiler-API.md
+++ b/Using-the-Compiler-API.md
@@ -13,8 +13,8 @@ npm install -g typescript
 npm link typescript
 ```
 
-You will also need the node defintion file for some of these samples.
-To aquire the defintion file, run:
+You will also need the node definition file for some of these samples.
+To acquire the definition file, run:
 
 ```
 npm install @types/node


### PR DESCRIPTION
Noticed a few typos when converting a project to the compiler